### PR TITLE
Implementing the per-project codestore

### DIFF
--- a/configs/assistants.yaml
+++ b/configs/assistants.yaml
@@ -1,6 +1,16 @@
 # Copyright (c) 2023-2024 AlertAvert.com. All rights reserved.
 # Author: Marco Massenzio (marco@alertavert.com)
 
+###### NOT IMPLEMENTED -- THIS IS NOT REALLY SUPPORTED YET ######
+#
+# Assistants are currently managed via OpenAI API, and we
+# do not yet support creating them either via API or UI.
+# The ones currently used have been manually created via OpenAI's
+# web interface.
+#
+# See Issue #18 for more details.
+######
+
 common: |
   You are Majordomo, a coding assistant for an experienced developer and only 
   send back the code, no explanation necessary. 

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -1,20 +1,45 @@
+# Majordomo configuration file (c) 2025 AlertAvert.com
 # Created M. Massenzio, 2024-05-27
 #
 # Sample Configuration file for Majordomo
+#
+# Its location can be configured via the `MAJORDOMO_CONFIG` environment variable,
+# or by passing the `--config` flag to the Majordomo CLI.
+# If neither is provided, the default location is `~/.majordomo/config.yaml`.
 
+# OpenAI API Key
+# Replace with yours, and do not share or commit to repository the real one
 api_key: "sk-1234567890abcdef1234567890abcdef"
+
+# Project ID for the OpenAI API - consider it
+# a confidential piece of information, do not share.
 project_id: "proj_1234567890abcdef1234567890abcdef"
 
-assistants: $HOME/.majordomo/data/instructions.yaml
-code_snippets: $HOME/.majordomo/data/code
-model: gpt-4o
+# OpenAI Model
+model: gpt-4o-mini
 
+# Folder for generated code.
+#
+# Either absolute, or relative: if the latter,
+# it is considered relative to the project's location.
+# Can be overridden in the project's configuration.
+#
+# If not specified here, we try to use the MAJORDOMO_CODE environment variable,
+# and if that is not set, we default to $HOME/.majordomo/code
+code_snippets: .majordomo/code
+
+# Active project at startup (should be saved every time it's changed in UI)
 active_project: Majordomo
+# List of projects for the Assistants.
 projects:
     - name: Majordomo
+      description: AI Agent for coding assistance
       location: $HOME/Development/AlertAvert/majordomo
     - name: common-utils
+      description: Shell scripting utilities
       location: $HOME/Development/common-utils
     - name: Chalk
       description: Backstage integration
+      # Example of a project with a different code_snippets location
+      code_snippets: /usr/share/chalk/majordomo
       location: $HOME/Development/Playgrounds/chalk-dev

--- a/pkg/completions/queries_test.go
+++ b/pkg/completions/queries_test.go
@@ -67,6 +67,18 @@ var _ = Describe("Majordomo", func() {
 			err := majordomo.SetActiveProject("non-existent-project")
 			Expect(err).To(HaveOccurred())
 		})
+		It("Will use the correct location for the code snippets", func() {
+			// First check that the Config has the correct values
+			cfg := majordomo.Config
+			prj := cfg.GetActiveProject()
+			Expect(prj).NotTo(BeNil())
+			Expect(prj.ResolvedCodeSnippetsDir).To(HaveSuffix("test/location/.majordomo"))
+			// This should also be what the CodeStore uses
+			Expect(majordomo.CodeStore).NotTo(BeNil())
+			// We cast the CodeStore to be a FilesystemStore to access the Location field.
+			fsStore := majordomo.CodeStore.(*preprocessors.FilesystemStore)
+			Expect(fsStore.DestCodeDir).To(HaveSuffix("test/location/.majordomo"))
+		})
 		It("will set the CodeStore to the new project's location", func() {
 			err := majordomo.SetActiveProject("test-project-2")
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,13 +12,22 @@ import (
 )
 
 const LocationEnv = "MAJORDOMO_CONFIG"
+const CodeLocationEnv = "MAJORDOMO_CODE"
 
 var DefaultConfigLocation = os.Getenv("HOME") + "/.majordomo/config.yaml"
+var DefaultCodeSnippetsLocation = os.Getenv("HOME") + "/.majordomo/code"
 
 type Project struct {
 	Name        string `yaml:"name" json:"name"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Location    string `yaml:"location" json:"location"`
+	// User-configured location for the code snippets for this project.
+	// It is never overwritten by the system.
+	CodeSnippets string `yaml:"code_snippets,omitempty" json:"code_snippets,omitempty"`
+
+	// Resolved path for code snippets for the project.
+	// This is what the system uses, but is not written to the config file.
+	ResolvedCodeSnippetsDir string `yaml:"-" json:"-"`
 }
 
 // String function makes the Project type a valid fmt.Stringer
@@ -28,16 +37,17 @@ func (p Project) String() string {
 
 type Config struct {
 	// LoadedFrom is the path from which the Config was loaded.
-	LoadedFrom        string `yaml:"-"`
+	LoadedFrom string `yaml:"-"`
 
 	// OpenAIApiKey is the API key to use for OpenAI API requests.
-	OpenAIApiKey      string `yaml:"api_key"`
+	OpenAIApiKey string `yaml:"api_key"`
 
 	// ProjectId is the ID of the project to use for OpenAI API requests.
-	ProjectId         string `yaml:"project_id"`
+	ProjectId string `yaml:"project_id"`
 
 	// AssistantsLocation is the path to the YAML file containing the instructions
 	// to create the assistants' system prompts.
+	// TODO: not supported yet (see #18)
 	AssistantsLocation string `yaml:"assistants"`
 
 	// ThreadsLocation is the path to the directory where the threads are stored.
@@ -45,17 +55,17 @@ type Config struct {
 
 	// CodeSnippetsDir is the name of the directory, inside each respective
 	// project's location, where the code snippets are stored.
-	CodeSnippetsDir   string `yaml:"code_snippets"`
+	CodeSnippetsDir string `yaml:"code_snippets"`
 
 	// Model is the name of the model to use for OpenAI API requests.
-	Model             string `yaml:"model"`
+	Model string `yaml:"model"`
 
 	// ActiveProject is the name of the project that is currently active and will
 	// be used to fetch the files from (and save snippets to).
-	ActiveProject string    `yaml:"active_project"`
+	ActiveProject string `yaml:"active_project"`
 
 	// Projects is a list of projects that are configured in the system.
-	Projects      []Project `yaml:"projects"`
+	Projects []Project `yaml:"projects"`
 }
 
 // Save writes the Config to a YAML file at the given filePath.
@@ -104,6 +114,7 @@ func LoadConfig(filepath string) (*Config, error) {
 		return nil, fmt.Errorf("error unmarshaling yaml: %w", err)
 	}
 
+	// TODO: not having any projects configured should be a valid state.
 	if len(c.Projects) == 0 {
 		// TODO: we should have a default project.
 		return nil, fmt.Errorf("no projects configured")
@@ -118,6 +129,30 @@ func LoadConfig(filepath string) (*Config, error) {
 	}
 	if c.ActiveProject == "" && len(c.Projects) > 0 {
 		c.ActiveProject = c.Projects[0].Name
+	}
+	// The code snippets, if not configured is read from the environment.
+	if c.CodeSnippetsDir == "" {
+		c.CodeSnippetsDir = os.Getenv(CodeLocationEnv)
+		if c.CodeSnippetsDir == "" {
+			c.CodeSnippetsDir = DefaultCodeSnippetsLocation
+		}
+	}
+
+	// Resolve the actual code snippets directory for each project.
+	for i, _ := range c.Projects {
+		p := &c.Projects[i]
+		// By default, we use the global code snippets directory.
+		var cs = c.CodeSnippetsDir
+		if p.CodeSnippets != "" {
+			// If the project has a code snippets directory configured, we use that.
+			cs = p.CodeSnippets
+		}
+		if !path.IsAbs(cs) {
+			// If the path is not absolute, we assume it is relative to the project's location.
+			p.ResolvedCodeSnippetsDir = path.Join(p.Location, cs)
+		} else {
+			p.ResolvedCodeSnippetsDir = cs
+		}
 	}
 	return &c, nil
 }

--- a/pkg/preprocessors/fs_store.go
+++ b/pkg/preprocessors/fs_store.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 AlertAvert.com. All rights reserved.
+ */
+
+package preprocessors
+
+import (
+	"errors"
+	"fmt"
+	"github.com/alertavert/gpt4-go/pkg/config"
+	"github.com/rs/zerolog/log"
+	"os"
+	"path/filepath"
+)
+
+const (
+	ErrorReadingCodeSnippet = "error while reading %s: %v"
+)
+
+type ProjectsStoreMap = map[string]*CodeStoreHandler
+
+var cache = make(ProjectsStoreMap)
+
+// FilesystemStore is a CodeStoreHandler that reads and writes code snippets from/to the filesystem
+type FilesystemStore struct {
+	// SourceCodeDir is the directory where the code snippets are read from
+	SourceCodeDir string
+	// DestCodeDir is the directory where the code snippets are saved to
+	DestCodeDir string
+}
+
+func (fp *FilesystemStore) GetSourceCode(codeMap *SourceCodeMap) error {
+	for relPath := range *codeMap {
+		content, err := os.ReadFile(filepath.Join(fp.SourceCodeDir, relPath))
+		if err != nil {
+			return errors.New(fmt.Sprintf(ErrorReadingCodeSnippet, relPath, err))
+		}
+		(*codeMap)[relPath] = string(content)
+	}
+	return nil
+}
+
+func (fp *FilesystemStore) PutSourceCode(codemap SourceCodeMap) error {
+	for relPath, content := range codemap {
+		absPath := filepath.Join(fp.DestCodeDir, relPath)
+		dir := filepath.Dir(absPath)
+		// Creates the directory if it doesn't exist
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			err := os.MkdirAll(dir, 0755)
+			if err != nil {
+				return err
+			}
+			log.Debug().
+				Str("path", dir).
+				Msg("new directory created to store snippets")
+		}
+		// Writes to the file in its respective directory
+		err := os.WriteFile(absPath, []byte(content), 0644)
+		if err != nil {
+			return err
+		}
+		log.Debug().
+			Str("path", absPath).
+			Str("relative_path", relPath).
+			Msg("Code saved to file")
+	}
+	return nil
+}
+
+// NewFilesystemStore creates a new filesystem-based CodeStoreHandler
+func NewFilesystemStore(sourceDir, destDir string) CodeStoreHandler {
+	return &FilesystemStore{
+		SourceCodeDir: sourceDir,
+		DestCodeDir:   destDir,
+	}
+}
+
+// GetCodeStoreHandler returns a CodeStoreHandler for the given project
+// Creating a new one if necessary.
+func GetCodeStoreHandler(project *config.Project) *CodeStoreHandler {
+	if cache[project.Name] == nil {
+		store := NewFilesystemStore(project.Location, project.ResolvedCodeSnippetsDir)
+		cache[project.Name] = &store
+	}
+	return cache[project.Name]
+}

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,7 +3,7 @@
 # Created by Marco Massenzio, 2023-07-13
 
 name: majordomo
-version: 0.6.1
+version: 0.7.0
 description: An LLM-powered code-generation assistant for expert developers
 author: Marco Massenzio (marco@alertavert.com)
 license: Proprietary


### PR DESCRIPTION
In the config.yaml, we can now specify a relative path folder, and it will be used for the code snippets for the project, relative to the `Project`'s `Location`