### PR TITLE
Updated API to retrieve a Project's conversations.

### DIFF
--- a/pkg/server/conversations_handler.go
+++ b/pkg/server/conversations_handler.go
@@ -3,40 +3,11 @@
 package server
 
 import (
-	"fmt"
 	"github.com/alertavert/gpt4-go/pkg/completions"
-	"github.com/alertavert/gpt4-go/pkg/conversations"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
-
-// threadsGetHandler handles GET requests to list all threads for a project
-func threadsGetHandler(assistant *completions.Majordomo) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		projectName := c.Query("project")
-		if projectName == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "project query parameter is required"})
-			return
-		}
-
-		// Check if project exists
-		project := assistant.Config.GetProject(projectName)
-		if project == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("project '%s' not found", projectName)})
-			return
-		}
-		threads := assistant.Threads.GetAllThreads(projectName)
-		if threads == nil {
-			threads = []conversations.Thread{}
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"project": projectName,
-			"threads": threads,
-		})
-	}
-}
 
 // threadGetByIdHandler handles GET requests for a specific thread
 func threadGetByIdHandler(assistant *completions.Majordomo) gin.HandlerFunc {

--- a/pkg/server/conversations_handler_test.go
+++ b/pkg/server/conversations_handler_test.go
@@ -53,50 +53,6 @@ var _ = Describe("/conversations endpoint", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Describe("GET /conversations", func() {
-		Context("With valid project parameter", func() {
-			It("should return all threads for the project", func() {
-				req, _ := http.NewRequest("GET", fmt.Sprintf("/conversations?project=%s", projectName), nil)
-				resp := httptest.NewRecorder()
-
-				router.ServeHTTP(resp, req)
-				Expect(resp.Code).To(Equal(http.StatusOK))
-				Expect(resp.Body.String()).To(ContainSubstring(testThread.ID))
-				Expect(resp.Body.String()).To(ContainSubstring(testThread.Name))
-			})
-
-			It("should return empty array when project has no threads", func() {
-				emptyProject := cfg.Projects[1].Name
-				req, _ := http.NewRequest("GET", fmt.Sprintf("/conversations?project=%s", emptyProject), nil)
-				resp := httptest.NewRecorder()
-
-				router.ServeHTTP(resp, req)
-				Expect(resp.Code).To(Equal(http.StatusOK))
-				Expect(resp.Body.String()).To(ContainSubstring(`"threads":[]`))
-			})
-		})
-
-		Context("With invalid project parameter", func() {
-			It("should return 400 when project parameter is missing", func() {
-				req, _ := http.NewRequest("GET", "/conversations", nil)
-				resp := httptest.NewRecorder()
-
-				router.ServeHTTP(resp, req)
-				Expect(resp.Code).To(Equal(http.StatusBadRequest))
-				Expect(resp.Body.String()).To(ContainSubstring("project query parameter is required"))
-			})
-
-			It("should return 404 when project doesn't exist", func() {
-				req, _ := http.NewRequest("GET", "/conversations?project=nonexistent", nil)
-				resp := httptest.NewRecorder()
-
-				router.ServeHTTP(resp, req)
-				Expect(resp.Code).To(Equal(http.StatusNotFound))
-				Expect(resp.Body.String()).To(ContainSubstring("project 'nonexistent' not found"))
-			})
-		})
-	})
-
 	Describe("GET /conversations/:thread_id", func() {
 		Context("With valid parameters", func() {
 			It("should return the specific thread", func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -54,7 +54,7 @@ func (s *Server) setupHandlers() {
 	cfg := s.assistant.Config
 	r.GET("/projects", projectsGetHandler(cfg))
 	r.GET("/projects/:project_name", projectDetailsGetHandler(cfg))
-	r.GET("/projects/:project_name/sessions", getSessionsForProjectHandler(s.assistant))
+	r.GET("/projects/:project_name/conversations", getConversationsForProjectHandler(s.assistant))
 	r.POST("/projects", projectPostHandler(cfg))
 	r.PUT("/projects", updateActiveProject(s.assistant))
 	r.PUT("/projects/:project_name", projectPutHandler(cfg))
@@ -64,7 +64,6 @@ func (s *Server) setupHandlers() {
 	r.GET("/assistants", assistantsGetHandler(s.assistant))
 
 	// Conversations routes
-	r.GET("/conversations", threadsGetHandler(s.assistant))
 	r.GET("/conversations/:thread_id", threadGetByIdHandler(s.assistant))
 }
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,7 +3,7 @@
 # Created by Marco Massenzio, 2023-07-13
 
 name: majordomo
-version: 0.7.0
+version: 0.7.1
 description: An LLM-powered code-generation assistant for expert developers
 author: Marco Massenzio (marco@alertavert.com)
 license: Proprietary


### PR DESCRIPTION
Removed redundant (and confusing) `/conversations?project=<Prj>` endpoint 
Also added tests to the existing `/projects/<Prj>/conversations` endpoint.